### PR TITLE
feat: Solent racing marks 2026 changes page (bead eiw)

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -6,4 +6,10 @@
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
+  <url>
+    <loc>https://guess-the-mark.verdient.co.uk/solent-racing-marks-2026/</loc>
+    <lastmod>2026-06-11</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.8</priority>
+  </url>
 </urlset>

--- a/public/solent-racing-marks-2026/index.html
+++ b/public/solent-racing-marks-2026/index.html
@@ -1,0 +1,717 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Solent Racing Marks 2026: What's Changed | Guess the Mark</title>
+    <meta
+      name="description"
+      content="What changed in the SCRA Solent racing marks for the 2026 season: 4 marks removed, 2 marks moved over 250 m, and 23 renamed or re-sponsored. Full breakdown for Solent racers."
+    />
+    <link rel="canonical" href="https://guess-the-mark.verdient.co.uk/solent-racing-marks-2026/" />
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="article" />
+    <meta property="og:title" content="Solent Racing Marks 2026: What's Changed" />
+    <meta
+      property="og:description"
+      content="What changed in the SCRA Solent racing marks for the 2026 season: 4 marks removed, 2 marks moved over 250 m, and 23 renamed or re-sponsored."
+    />
+    <meta
+      property="og:url"
+      content="https://guess-the-mark.verdient.co.uk/solent-racing-marks-2026/"
+    />
+    <meta property="og:site_name" content="Guess the Mark" />
+
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Article",
+        "headline": "Solent Racing Marks 2026: What's Changed",
+        "description": "What changed in the SCRA Solent racing marks for the 2026 season: 4 marks removed, 2 marks moved over 250 m, and 23 renamed or re-sponsored.",
+        "datePublished": "2026-06-11",
+        "publisher": {
+          "@type": "Organization",
+          "name": "Guess the Mark",
+          "url": "https://guess-the-mark.verdient.co.uk/"
+        },
+        "about": {
+          "@type": "Thing",
+          "name": "Solent racing marks"
+        }
+      }
+    </script>
+
+    <style>
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      :root {
+        --navy: #1b2a4a;
+        --navy-light: #2a3d5e;
+        --gold: #c9a962;
+        --gold-light: #e8d49a;
+        --off-white: #fdfcfb;
+        --warm-grey: #f8f7f5;
+        --border: #e8e6e1;
+        --text: #2d3748;
+        --text-muted: #718096;
+        --serif: Georgia, "Times New Roman", serif;
+        --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      }
+
+      html {
+        font-size: 16px;
+        scroll-behavior: smooth;
+      }
+
+      body {
+        background: var(--off-white);
+        color: var(--text);
+        font-family: var(--sans);
+        line-height: 1.6;
+      }
+
+      a {
+        color: var(--navy);
+        text-decoration: underline;
+      }
+
+      a:hover {
+        color: var(--navy-light);
+      }
+
+      /* ── Header ── */
+      header {
+        background: var(--navy);
+        border-bottom: 4px solid var(--gold);
+        padding: 2.5rem 1rem 2rem;
+        text-align: center;
+      }
+
+      header .eyebrow {
+        font-size: 0.7rem;
+        font-family: var(--sans);
+        text-transform: uppercase;
+        letter-spacing: 0.15em;
+        color: var(--gold-light);
+        margin-bottom: 0.6rem;
+      }
+
+      header h1 {
+        font-family: var(--serif);
+        font-size: clamp(1.5rem, 4vw, 2.25rem);
+        font-weight: 600;
+        color: #fff;
+        line-height: 1.25;
+        max-width: 680px;
+        margin: 0 auto 0.75rem;
+      }
+
+      header .byline {
+        font-size: 0.8rem;
+        color: #94a3b8;
+        font-family: var(--sans);
+      }
+
+      /* ── Layout ── */
+      main {
+        max-width: 780px;
+        margin: 0 auto;
+        padding: 2.5rem 1.25rem 4rem;
+      }
+
+      section {
+        margin-bottom: 2.5rem;
+      }
+
+      h2 {
+        font-family: var(--serif);
+        font-size: 1.3rem;
+        font-weight: 600;
+        color: var(--navy);
+        border-bottom: 2px solid var(--gold);
+        padding-bottom: 0.4rem;
+        margin-bottom: 1rem;
+      }
+
+      h3 {
+        font-family: var(--serif);
+        font-size: 1.05rem;
+        font-weight: 600;
+        color: var(--navy);
+        margin: 1.25rem 0 0.5rem;
+      }
+
+      p {
+        font-size: 0.9rem;
+        line-height: 1.7;
+        color: var(--text);
+        margin-bottom: 0.75rem;
+      }
+
+      /* ── Summary strip ── */
+      .summary-strip {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+        gap: 0.75rem;
+        background: var(--warm-grey);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 1rem 1.25rem;
+        margin-bottom: 2rem;
+      }
+
+      .stat {
+        text-align: center;
+      }
+
+      .stat .num {
+        display: block;
+        font-family: var(--serif);
+        font-size: 1.6rem;
+        font-weight: 600;
+        color: var(--navy);
+        line-height: 1;
+      }
+
+      .stat .label {
+        display: block;
+        font-size: 0.7rem;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: var(--text-muted);
+        margin-top: 0.3rem;
+      }
+
+      /* ── Callout box ── */
+      .callout {
+        background: var(--warm-grey);
+        border-left: 3px solid var(--navy);
+        padding: 0.85rem 1rem;
+        border-radius: 0 6px 6px 0;
+        margin-bottom: 1rem;
+      }
+
+      .callout.gold {
+        border-left-color: var(--gold);
+      }
+
+      /* ── Moved marks ── */
+      .mark-moved {
+        background: #fff;
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 1rem 1.25rem;
+        margin-bottom: 0.75rem;
+        display: flex;
+        align-items: flex-start;
+        gap: 1rem;
+      }
+
+      .mark-moved .code {
+        font-family: "Courier New", monospace;
+        font-size: 0.85rem;
+        font-weight: 700;
+        background: var(--navy);
+        color: #fff;
+        padding: 0.2rem 0.5rem;
+        border-radius: 4px;
+        white-space: nowrap;
+        margin-top: 0.15rem;
+      }
+
+      .mark-moved .detail strong {
+        display: block;
+        font-size: 0.9rem;
+        color: var(--navy);
+        margin-bottom: 0.15rem;
+      }
+
+      .mark-moved .detail span {
+        font-size: 0.8rem;
+        color: var(--text-muted);
+      }
+
+      .distance-pill {
+        margin-left: auto;
+        font-size: 0.75rem;
+        font-weight: 600;
+        background: #fef3c7;
+        color: #92400e;
+        border: 1px solid #fcd34d;
+        border-radius: 999px;
+        padding: 0.2rem 0.6rem;
+        white-space: nowrap;
+        align-self: center;
+      }
+
+      /* ── Removed marks ── */
+      ul.removed {
+        list-style: none;
+        padding: 0;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+      }
+
+      ul.removed li {
+        background: #fff;
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        padding: 0.4rem 0.75rem;
+        font-size: 0.85rem;
+        font-family: "Courier New", monospace;
+      }
+
+      ul.removed li .name {
+        font-family: var(--sans);
+        font-size: 0.8rem;
+        color: var(--text-muted);
+        margin-left: 0.4rem;
+      }
+
+      /* ── Table ── */
+      .table-wrap {
+        overflow-x: auto;
+        border: 1px solid var(--border);
+        border-radius: 8px;
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.82rem;
+      }
+
+      thead {
+        background: var(--navy);
+        color: #fff;
+      }
+
+      thead th {
+        padding: 0.6rem 0.85rem;
+        text-align: left;
+        font-weight: 600;
+        font-size: 0.75rem;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+      }
+
+      tbody tr:nth-child(even) {
+        background: var(--warm-grey);
+      }
+
+      tbody tr:nth-child(odd) {
+        background: #fff;
+      }
+
+      tbody td {
+        padding: 0.55rem 0.85rem;
+        vertical-align: top;
+        border-bottom: 1px solid var(--border);
+        color: var(--text);
+        line-height: 1.4;
+      }
+
+      tbody td:first-child {
+        font-family: "Courier New", monospace;
+        font-weight: 700;
+        color: var(--navy);
+      }
+
+      tbody td .old {
+        color: var(--text-muted);
+        text-decoration: line-through;
+        font-size: 0.78rem;
+      }
+
+      .badge {
+        display: inline-block;
+        font-size: 0.65rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        padding: 0.15rem 0.4rem;
+        border-radius: 3px;
+        margin-left: 0.35rem;
+        vertical-align: middle;
+      }
+
+      .badge-typo {
+        background: #e0f2fe;
+        color: #0369a1;
+      }
+
+      .badge-new-sponsor {
+        background: #d1fae5;
+        color: #065f46;
+      }
+
+      /* ── Data-quality note ── */
+      .data-note {
+        font-size: 0.78rem;
+        color: var(--text-muted);
+        background: var(--warm-grey);
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        padding: 0.6rem 0.85rem;
+        margin-top: 0.75rem;
+      }
+
+      /* ── CTA ── */
+      .cta {
+        background: var(--navy);
+        border-radius: 10px;
+        padding: 2rem 1.5rem;
+        text-align: center;
+        margin-top: 3rem;
+      }
+
+      .cta h2 {
+        font-family: var(--serif);
+        color: #fff;
+        font-size: 1.25rem;
+        border: none;
+        padding: 0;
+        margin-bottom: 0.6rem;
+      }
+
+      .cta p {
+        color: #94a3b8;
+        font-size: 0.85rem;
+        margin-bottom: 1.25rem;
+      }
+
+      .cta a.btn {
+        display: inline-block;
+        background: var(--gold);
+        color: var(--navy);
+        font-weight: 700;
+        font-size: 0.9rem;
+        padding: 0.7rem 1.75rem;
+        border-radius: 6px;
+        text-decoration: none;
+        transition: background 0.15s;
+      }
+
+      .cta a.btn:hover {
+        background: var(--gold-light);
+      }
+
+      /* ── Footer ── */
+      footer {
+        text-align: center;
+        font-size: 0.75rem;
+        color: var(--text-muted);
+        padding: 1.5rem 1rem 2rem;
+        border-top: 1px solid var(--border);
+      }
+
+      footer a {
+        color: var(--text-muted);
+      }
+
+      @media (max-width: 480px) {
+        .mark-moved {
+          flex-direction: column;
+          gap: 0.5rem;
+        }
+        .distance-pill {
+          align-self: flex-start;
+        }
+        header {
+          padding: 2rem 1rem 1.5rem;
+        }
+      }
+    </style>
+  </head>
+
+  <body>
+    <header>
+      <p class="eyebrow">Solent Racing &mdash; Season Update</p>
+      <h1>Solent Racing Marks 2026: What&#8217;s Changed</h1>
+      <p class="byline">Published 11 June 2026 &middot; Based on SCRA 2026 season data</p>
+    </header>
+
+    <main>
+      <!-- Summary stats -->
+      <div class="summary-strip">
+        <div class="stat">
+          <span class="num">157</span>
+          <span class="label">Marks 2026</span>
+        </div>
+        <div class="stat">
+          <span class="num">161</span>
+          <span class="label">Marks 2025</span>
+        </div>
+        <div class="stat">
+          <span class="num">4</span>
+          <span class="label">Removed</span>
+        </div>
+        <div class="stat">
+          <span class="num">2</span>
+          <span class="label">Moved &gt;50&nbsp;m</span>
+        </div>
+        <div class="stat">
+          <span class="num">23</span>
+          <span class="label">Renamed</span>
+        </div>
+      </div>
+
+      <!-- Intro -->
+      <section>
+        <p>
+          Each year the
+          <a href="https://www.scra.org.uk/" target="_blank" rel="noopener noreferrer"
+            >Solent Cruising and Racing Association (SCRA)</a
+          >
+          publishes the definitive list of racing marks for the Solent. The data is collated and
+          distributed by
+          <a
+            href="https://winningtides.co.uk/pages/buoyracer.htm"
+            target="_blank"
+            rel="noopener noreferrer"
+            >Winning Tides</a
+          >
+          and forms the basis for most club racing in the area.
+        </p>
+        <p>
+          For the 2026 season there are <strong>157 marks</strong>, down from 161 in 2025. The net
+          reduction comes from four marks being removed with none added. Beyond the removals, two
+          marks shifted position by more than 250&nbsp;metres &mdash; meaningful for course-setting
+          and tactical planning &mdash; and 23 marks changed name, mostly reflecting new or departed
+          sponsors.
+        </p>
+        <p>
+          This page breaks down every change, starting with the positional moves that matter most to
+          racers.
+        </p>
+      </section>
+
+      <!-- Moved marks -->
+      <section>
+        <h2>Marks that moved</h2>
+        <div class="callout">
+          <p style="margin: 0; font-size: 0.85rem">
+            A mark moving more than 50&nbsp;m can shift a rounding gate, change the lay-line, or
+            require a course amendment notice. Both changes below are significant at race pace.
+          </p>
+        </div>
+
+        <div class="mark-moved">
+          <span class="code">13</span>
+          <div class="detail">
+            <strong>Parkstone YC</strong>
+            <span>Poole Harbour entrance &mdash; moved approximately 278&nbsp;m</span>
+          </div>
+          <span class="distance-pill">278 m</span>
+        </div>
+
+        <div class="mark-moved">
+          <span class="code">2D</span>
+          <div class="detail">
+            <strong>Lymington Yacht Haven</strong>
+            <span>Lymington River &mdash; moved approximately 268&nbsp;m</span>
+          </div>
+          <span class="distance-pill">268 m</span>
+        </div>
+      </section>
+
+      <!-- Removed marks -->
+      <section>
+        <h2>Marks removed</h2>
+        <p>
+          Four marks are no longer in the 2026 dataset. If your club&#8217;s standing instructions
+          or pilot books reference these, they will need updating.
+        </p>
+        <ul class="removed">
+          <li><strong>5N</strong><span class="name">Mary Rose</span></li>
+          <li><strong>71</strong><span class="name">Mark</span></li>
+          <li><strong>75</strong><span class="name">Magazine</span></li>
+          <li><strong>7F</strong><span class="name">Jib</span></li>
+        </ul>
+      </section>
+
+      <!-- Renamed / re-sponsored -->
+      <section>
+        <h2>Renamed &amp; re-sponsored marks</h2>
+        <p>
+          Sponsor turnover accounts for the majority of name changes each season. The table below
+          lists all 23 changes. Typo corrections and data-quality fixes are labelled separately.
+        </p>
+
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Code</th>
+                <th>2025 name</th>
+                <th>2026 name</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>12</td>
+                <td>MB/EYE Marine / Christchurch SC</td>
+                <td>Mid Bay Buoy</td>
+              </tr>
+              <tr>
+                <td>22</td>
+                <td>Charles Stanley</td>
+                <td>Raymond James Charles Stanley</td>
+              </tr>
+              <tr>
+                <td>24</td>
+                <td>Now Students</td>
+                <td>BDM CX</td>
+              </tr>
+              <tr>
+                <td>25</td>
+                <td>Jeremy Rogers Contessa</td>
+                <td>Contessa 26 Association</td>
+              </tr>
+              <tr>
+                <td>27</td>
+                <td>Adam Harding-Doneney</td>
+                <td>
+                  Adam Harding-Domeney
+                  <span class="badge badge-typo">typo fix</span>
+                </td>
+              </tr>
+              <tr>
+                <td>2A</td>
+                <td>Embley School</td>
+                <td>Hill Robinson</td>
+              </tr>
+              <tr>
+                <td>2K</td>
+                <td>Greetings Fintech</td>
+                <td>
+                  Greenings Fintech
+                  <span class="badge badge-typo">typo fix</span>
+                </td>
+              </tr>
+              <tr>
+                <td>3C</td>
+                <td>Craft insure</td>
+                <td>Basher</td>
+              </tr>
+              <tr>
+                <td>3F</td>
+                <td>Monex Marine</td>
+                <td>Markby</td>
+              </tr>
+              <tr>
+                <td>3S</td>
+                <td>TeamO</td>
+                <td>SCRA.ORG.UK</td>
+              </tr>
+              <tr>
+                <td>40</td>
+                <td>Haven Knox Johnson Specialist</td>
+                <td>
+                  Haven Knox Johnston Specialist
+                  <span class="badge badge-typo">typo fix</span>
+                </td>
+              </tr>
+              <tr>
+                <td>4E</td>
+                <td>Jane</td>
+                <td>Andy Cassell</td>
+              </tr>
+              <tr>
+                <td>4K</td>
+                <td>Royal London YC</td>
+                <td>Royal London</td>
+              </tr>
+              <tr>
+                <td>4L</td>
+                <td>William</td>
+                <td>Jane</td>
+              </tr>
+              <tr>
+                <td>50</td>
+                <td>Fairhall West</td>
+                <td>
+                  Fairhall West
+                  <span class="badge badge-new-sponsor">newly sponsored</span>
+                </td>
+              </tr>
+              <tr>
+                <td>51</td>
+                <td>SBSC Central</td>
+                <td>
+                  SBSC Central
+                  <span class="badge badge-new-sponsor">newly sponsored</span>
+                </td>
+              </tr>
+              <tr>
+                <td>5E</td>
+                <td>Warsash Sailing Club</td>
+                <td>Stokes Bay East</td>
+              </tr>
+              <tr>
+                <td>5K</td>
+                <td>Yola</td>
+                <td>Naomi House &amp; Jacksplace</td>
+              </tr>
+              <tr>
+                <td>5P</td>
+                <td>Naomi House and Jacksplace</td>
+                <td>www.victoryclass.org.uk</td>
+              </tr>
+              <tr>
+                <td>70</td>
+                <td>Cathead</td>
+                <td>Warsash Sailing Club</td>
+              </tr>
+              <tr>
+                <td>74</td>
+                <td>Sposa</td>
+                <td>William</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <div class="data-note">
+          <strong>Notes:</strong>
+          Mark 3G shows &#8220;Cowes Week 200&#8221; in the source data &mdash; this appears to be
+          an upstream truncation of &#8220;Cowes Week 2026&#8221; and is not a real name change.
+          Mark 5Q reflects a character-encoding normalisation only (special character replaced with
+          an asterisk). Marks 50 and 51 retain their nautical names but are newly carrying a sponsor
+          designation in the source dataset.
+        </div>
+      </section>
+
+      <!-- CTA -->
+      <div class="cta">
+        <h2>Know your 2026 marks?</h2>
+        <p>
+          Put your knowledge to the test on the 157 marks now active in the Solent. Beginner to
+          advanced &mdash; how well do you really know the patch?
+        </p>
+        <a href="/" class="btn">Play Guess the Mark &rarr;</a>
+      </div>
+    </main>
+
+    <footer>
+      <p>
+        Mark data:
+        <a href="https://www.scra.org.uk/" target="_blank" rel="noopener noreferrer">SCRA</a> via
+        <a
+          href="https://winningtides.co.uk/pages/buoyracer.htm"
+          target="_blank"
+          rel="noopener noreferrer"
+          >Winning Tides</a
+        >. &copy; 2026 Guess the Mark.
+      </p>
+    </footer>
+  </body>
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -285,6 +285,14 @@ function App() {
                     SCRA
                   </a>
                 </p>
+                <p className="mt-1">
+                  <a
+                    href="/solent-racing-marks-2026/"
+                    className="text-slate-500 hover:text-[#1B2A4A] underline"
+                  >
+                    2026 mark changes
+                  </a>
+                </p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary

- Adds `public/solent-racing-marks-2026/index.html` — a self-contained static page served by the Cloudflare Workers asset layer at `/solent-racing-marks-2026/`
- Covers the full 2025→2026 season diff: 4 removed, 2 moved >250 m (Parkstone YC 278 m, Lymington Yacht Haven 268 m), 21 sponsor renames, 3 typo corrections, 2 newly-sponsored marks
- SEO head: title, meta description, canonical URL, Open Graph tags, `Article` JSON-LD (datePublished 2026-06-11)
- Sitemap updated with the new URL (priority 0.8, changefreq yearly)
- Footer link "2026 mark changes" added to `App.tsx` so the page is internally linked and not orphaned for crawlers

## Page structure

```
Header (navy/gold)
  └─ "Solent Racing Marks 2026: What's Changed"
Summary strip: 157 marks | 161 marks | 4 removed | 2 moved | 23 renamed
Section: Marks that moved (cards with distance pills)
Section: Marks removed (code chips)
Section: Renamed & re-sponsored (table with typo/newly-sponsored badges, data-quality note)
CTA: "Play Guess the Mark →" link to /
Footer: SCRA + Winning Tides attribution
```

## Test plan

- [x] `pnpm run ci` passes (format check, lint, tests, build)
- [x] `GET /solent-racing-marks-2026/` returns HTTP 200 from wrangler dev
- [x] `GET /` still returns the SPA (confirmed 200)
- [x] Static page in `dist/client/solent-racing-marks-2026/index.html` after build

🤖 Generated with [Claude Code](https://claude.com/claude-code)