### PR TITLE
feat: /learn/ tutorial page — buoyage explainer + how to play (bead cqn)

### DIFF
--- a/public/learn/index.html
+++ b/public/learn/index.html
@@ -1,0 +1,1027 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Solent Racing Marks Explained: Buoyage Guide &amp; How to Play | Guess the Mark</title>
+    <meta
+      name="description"
+      content="Learn the colours and shapes of Solent racing marks — port, starboard, cardinal, safe water, and special marks explained with diagrams. Plus how Guess the Mark is scored."
+    />
+    <link rel="canonical" href="https://guess-the-mark.verdient.co.uk/learn/" />
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="article" />
+    <meta
+      property="og:title"
+      content="Solent Racing Marks Explained: Buoyage Guide &amp; How to Play"
+    />
+    <meta
+      property="og:description"
+      content="The complete guide to Solent racing marks: IALA buoyage types, how cardinal marks work, how Guess the Mark is scored, and tips for learning all 157 Solent marks."
+    />
+    <meta property="og:url" content="https://guess-the-mark.verdient.co.uk/learn/" />
+    <meta property="og:site_name" content="Guess the Mark" />
+
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@graph": [
+          {
+            "@type": "Article",
+            "headline": "Solent Racing Marks Explained: Buoyage Guide & How to Play",
+            "description": "The complete guide to Solent racing marks: IALA buoyage types, how cardinal marks work, how Guess the Mark is scored, and tips for learning all 157 Solent marks.",
+            "datePublished": "2026-06-11",
+            "publisher": {
+              "@type": "Organization",
+              "name": "Guess the Mark",
+              "url": "https://guess-the-mark.verdient.co.uk/"
+            },
+            "about": {
+              "@type": "Thing",
+              "name": "IALA maritime buoyage, Solent racing marks"
+            }
+          },
+          {
+            "@type": "FAQPage",
+            "mainEntity": [
+              {
+                "@type": "Question",
+                "name": "What do the colours of racing marks mean?",
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": "Red marks are port-hand lateral marks — you leave them to port (your left) when heading upstream or into harbour. Green marks are starboard-hand lateral marks — leave them to starboard (your right). Yellow marks are special marks, which in the Solent are almost always racing marks — they mark racing courses, not navigation hazards. Red-and-white vertically striped marks are safe water marks, indicating open water all around."
+                }
+              },
+              {
+                "@type": "Question",
+                "name": "What is a cardinal mark?",
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": "A cardinal mark is a black-and-yellow buoy that tells you which side of a hazard has safe water. The name comes from the four cardinal compass points. A north cardinal mark (black over yellow) means safe water is to the north of it; a south cardinal mark (yellow over black) means safe water is to the south. East cardinals have black-yellow-black bands and west cardinals have yellow-black-yellow bands."
+                }
+              },
+              {
+                "@type": "Question",
+                "name": "How many racing marks are in the Solent?",
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": "There are 157 racing marks in the 2026 SCRA Solent racing mark dataset, down from 161 in 2025. These marks are managed by the Solent Cruising and Racing Association (SCRA) and are used by clubs throughout the Solent for race course setting."
+                }
+              },
+              {
+                "@type": "Question",
+                "name": "What is a special mark?",
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": "A special mark is a yellow buoy used to indicate a special area or feature — in the Solent, almost all dedicated racing marks are special marks. They are not navigation hazards and do not carry the same pass-on-one-side rule as lateral marks. Racers round them as directed by the sailing instructions."
+                }
+              }
+            ]
+          }
+        ]
+      }
+    </script>
+
+    <style>
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      :root {
+        --navy: #1b2a4a;
+        --navy-light: #2a3d5e;
+        --gold: #c9a962;
+        --gold-light: #e8d49a;
+        --off-white: #fdfcfb;
+        --warm-grey: #f8f7f5;
+        --border: #e8e6e1;
+        --text: #2d3748;
+        --text-muted: #718096;
+        --serif: Georgia, "Times New Roman", serif;
+        --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      }
+
+      html {
+        font-size: 16px;
+        scroll-behavior: smooth;
+      }
+
+      body {
+        background: var(--off-white);
+        color: var(--text);
+        font-family: var(--sans);
+        line-height: 1.6;
+      }
+
+      a {
+        color: var(--navy);
+        text-decoration: underline;
+      }
+
+      a:hover {
+        color: var(--navy-light);
+      }
+
+      /* ── Header ── */
+      header {
+        background: var(--navy);
+        border-bottom: 4px solid var(--gold);
+        padding: 2.5rem 1rem 2rem;
+        text-align: center;
+      }
+
+      header .eyebrow {
+        font-size: 0.7rem;
+        font-family: var(--sans);
+        text-transform: uppercase;
+        letter-spacing: 0.15em;
+        color: var(--gold-light);
+        margin-bottom: 0.6rem;
+      }
+
+      header h1 {
+        font-family: var(--serif);
+        font-size: clamp(1.5rem, 4vw, 2.25rem);
+        font-weight: 600;
+        color: #fff;
+        line-height: 1.25;
+        max-width: 680px;
+        margin: 0 auto 0.75rem;
+      }
+
+      header .byline {
+        font-size: 0.8rem;
+        color: #94a3b8;
+        font-family: var(--sans);
+      }
+
+      /* ── Layout ── */
+      main {
+        max-width: 780px;
+        margin: 0 auto;
+        padding: 2.5rem 1.25rem 4rem;
+      }
+
+      section {
+        margin-bottom: 2.5rem;
+      }
+
+      h2 {
+        font-family: var(--serif);
+        font-size: 1.3rem;
+        font-weight: 600;
+        color: var(--navy);
+        border-bottom: 2px solid var(--gold);
+        padding-bottom: 0.4rem;
+        margin-bottom: 1rem;
+      }
+
+      h3 {
+        font-family: var(--serif);
+        font-size: 1.05rem;
+        font-weight: 600;
+        color: var(--navy);
+        margin: 1.25rem 0 0.5rem;
+      }
+
+      p {
+        font-size: 0.9rem;
+        line-height: 1.7;
+        color: var(--text);
+        margin-bottom: 0.75rem;
+      }
+
+      /* ── Callout box ── */
+      .callout {
+        background: var(--warm-grey);
+        border-left: 3px solid var(--navy);
+        padding: 0.85rem 1rem;
+        border-radius: 0 6px 6px 0;
+        margin-bottom: 1rem;
+      }
+
+      .callout.gold {
+        border-left-color: var(--gold);
+      }
+
+      /* ── Mark rows ── */
+      .mark-list {
+        background: #fff;
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        overflow: hidden;
+        margin-bottom: 1rem;
+      }
+
+      .mark-row {
+        display: flex;
+        align-items: flex-start;
+        gap: 1rem;
+        padding: 0.9rem 1.1rem;
+        border-bottom: 1px solid var(--border);
+      }
+
+      .mark-row:last-child {
+        border-bottom: none;
+      }
+
+      .mark-icon-cell {
+        flex-shrink: 0;
+        width: 52px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding-top: 0.1rem;
+      }
+
+      .mark-info strong {
+        display: block;
+        font-size: 0.9rem;
+        color: var(--navy);
+        margin-bottom: 0.2rem;
+      }
+
+      .mark-info p {
+        margin: 0;
+        font-size: 0.85rem;
+        color: var(--text-muted);
+        line-height: 1.5;
+      }
+
+      .symbol-code {
+        display: inline-block;
+        font-family: "Courier New", monospace;
+        font-size: 0.75rem;
+        font-weight: 700;
+        background: var(--navy);
+        color: #fff;
+        padding: 0.1rem 0.4rem;
+        border-radius: 3px;
+        margin-right: 0.35rem;
+        vertical-align: middle;
+      }
+
+      /* ── Cardinal grid ── */
+      .cardinal-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 0.75rem;
+        margin-bottom: 1rem;
+      }
+
+      .cardinal-card {
+        background: #fff;
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 1rem;
+        display: flex;
+        align-items: flex-start;
+        gap: 0.85rem;
+      }
+
+      .cardinal-card .mark-icon-cell {
+        width: 44px;
+      }
+
+      .cardinal-card strong {
+        display: block;
+        font-size: 0.85rem;
+        color: var(--navy);
+        margin-bottom: 0.15rem;
+      }
+
+      .cardinal-card .bands {
+        font-size: 0.78rem;
+        font-family: "Courier New", monospace;
+        color: var(--text-muted);
+        margin-bottom: 0.3rem;
+      }
+
+      .cardinal-card p {
+        font-size: 0.82rem;
+        margin: 0;
+        color: var(--text);
+        line-height: 1.5;
+      }
+
+      /* ── Table ── */
+      .table-wrap {
+        overflow-x: auto;
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        margin-bottom: 1rem;
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.82rem;
+      }
+
+      thead {
+        background: var(--navy);
+        color: #fff;
+      }
+
+      thead th {
+        padding: 0.6rem 0.85rem;
+        text-align: left;
+        font-weight: 600;
+        font-size: 0.75rem;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+      }
+
+      tbody tr:nth-child(even) {
+        background: var(--warm-grey);
+      }
+
+      tbody tr:nth-child(odd) {
+        background: #fff;
+      }
+
+      tbody td {
+        padding: 0.55rem 0.85rem;
+        vertical-align: top;
+        border-bottom: 1px solid var(--border);
+        color: var(--text);
+        line-height: 1.4;
+      }
+
+      tbody tr:last-child td {
+        border-bottom: none;
+      }
+
+      /* ── Scoring cards ── */
+      .score-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+        gap: 0.75rem;
+        margin-bottom: 1rem;
+      }
+
+      .score-card {
+        background: #fff;
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 0.85rem 1rem;
+        text-align: center;
+      }
+
+      .score-card .num {
+        display: block;
+        font-family: var(--serif);
+        font-size: 1.4rem;
+        font-weight: 600;
+        color: var(--navy);
+        line-height: 1.1;
+      }
+
+      .score-card .label {
+        display: block;
+        font-size: 0.7rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--text-muted);
+        margin-top: 0.3rem;
+      }
+
+      /* ── Tips list ── */
+      .tip-list {
+        list-style: none;
+        padding: 0;
+      }
+
+      .tip-list li {
+        background: #fff;
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 0.85rem 1.1rem 0.85rem 1.5rem;
+        margin-bottom: 0.6rem;
+        position: relative;
+        font-size: 0.88rem;
+        line-height: 1.55;
+      }
+
+      .tip-list li::before {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: 0;
+        bottom: 0;
+        width: 4px;
+        background: var(--gold);
+        border-radius: 8px 0 0 8px;
+      }
+
+      .tip-list li strong {
+        display: block;
+        color: var(--navy);
+        margin-bottom: 0.2rem;
+        font-size: 0.9rem;
+      }
+
+      /* ── CTA ── */
+      .cta {
+        background: var(--navy);
+        border-radius: 10px;
+        padding: 2rem 1.5rem;
+        text-align: center;
+        margin-top: 3rem;
+      }
+
+      .cta h2 {
+        font-family: var(--serif);
+        color: #fff;
+        font-size: 1.25rem;
+        border: none;
+        padding: 0;
+        margin-bottom: 0.6rem;
+      }
+
+      .cta p {
+        color: #94a3b8;
+        font-size: 0.85rem;
+        margin-bottom: 1.25rem;
+      }
+
+      .cta a.btn {
+        display: inline-block;
+        background: var(--gold);
+        color: var(--navy);
+        font-weight: 700;
+        font-size: 0.9rem;
+        padding: 0.7rem 1.75rem;
+        border-radius: 6px;
+        text-decoration: none;
+        transition: background 0.15s;
+      }
+
+      .cta a.btn:hover {
+        background: var(--gold-light);
+      }
+
+      /* ── Footer ── */
+      footer {
+        text-align: center;
+        font-size: 0.75rem;
+        color: var(--text-muted);
+        padding: 1.5rem 1rem 2rem;
+        border-top: 1px solid var(--border);
+      }
+
+      footer a {
+        color: var(--text-muted);
+      }
+
+      @media (max-width: 540px) {
+        .cardinal-grid {
+          grid-template-columns: 1fr;
+        }
+
+        header {
+          padding: 2rem 1rem 1.5rem;
+        }
+      }
+    </style>
+  </head>
+
+  <body>
+    <header>
+      <p class="eyebrow">Solent Racing &mdash; Navigation Guide</p>
+      <h1>Solent Racing Marks: A Complete Guide</h1>
+      <p class="byline">
+        Published 11 June 2026 &middot; IALA Maritime Buoyage &middot; 157 marks, 2026 season
+      </p>
+    </header>
+
+    <main>
+      <!-- Intro -->
+      <section>
+        <p>
+          The Solent is home to 157 racing marks managed by the
+          <a href="https://www.scra.org.uk/" target="_blank" rel="noopener noreferrer"
+            >Solent Cruising and Racing Association (SCRA)</a
+          >. To race confidently in these waters you need to recognise each mark type on sight
+          &mdash; and that&#8217;s exactly what <a href="/">Guess the Mark</a> is designed to train.
+          This guide explains the mark types, how the game works, and how to get up to speed
+          quickly.
+        </p>
+      </section>
+
+      <!-- Section 1: Understanding the marks -->
+      <section>
+        <h2>1. Understanding the marks</h2>
+
+        <p>
+          All marks in UK waters follow the
+          <strong>IALA Maritime Buoyage System (Region A)</strong>. There are five main categories.
+          The icons below are identical to those shown in the game.
+        </p>
+
+        <h3>Lateral marks</h3>
+        <p>
+          Lateral marks define safe channels. In Region A, red marks are on the port (left) side
+          when entering harbour; green marks are on the starboard (right) side.
+        </p>
+
+        <div class="mark-list">
+          <div class="mark-row">
+            <div class="mark-icon-cell">
+              <svg
+                width="48"
+                height="48"
+                viewBox="0 0 24 24"
+                aria-label="Port hand mark — red cylinder"
+              >
+                <rect
+                  x="8"
+                  y="4"
+                  width="8"
+                  height="16"
+                  fill="#dc2626"
+                  stroke="#374151"
+                  stroke-width="1"
+                />
+              </svg>
+            </div>
+            <div class="mark-info">
+              <strong><span class="symbol-code">R</span> Port Hand Mark</strong>
+              <p>
+                Red cylindrical buoy. Leave to port (your left) when entering harbour or proceeding
+                upstream. Pass it on your left, keeping it between you and the port-side hazard.
+              </p>
+            </div>
+          </div>
+
+          <div class="mark-row">
+            <div class="mark-icon-cell">
+              <svg
+                width="48"
+                height="48"
+                viewBox="0 0 24 24"
+                aria-label="Starboard hand mark — green cylinder"
+              >
+                <rect
+                  x="8"
+                  y="4"
+                  width="8"
+                  height="16"
+                  fill="#16a34a"
+                  stroke="#374151"
+                  stroke-width="1"
+                />
+              </svg>
+            </div>
+            <div class="mark-info">
+              <strong><span class="symbol-code">G</span> Starboard Hand Mark</strong>
+              <p>
+                Green cylindrical buoy. Leave to starboard (your right) when entering harbour or
+                proceeding upstream. Pass it on your right.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <h3>Cardinal marks</h3>
+        <p>
+          Cardinal marks use black and yellow horizontal bands to indicate which direction has safe
+          water. The name of each mark (north, south, east, west) tells you the safe side to pass
+          on. Learn the band pattern and you can read any cardinal mark instantly.
+        </p>
+
+        <div class="callout">
+          <p style="margin: 0; font-size: 0.85rem">
+            <strong>Memory aid:</strong> For North and South cardinals, the black band is always
+            nearest to that pole &mdash; black on top for North, black on bottom for South. For East
+            and West, remember the shape: East (BYB) has black squeezing a yellow centre like a
+            rising sun; West (YBY) has black in the middle like an hourglass.
+          </p>
+        </div>
+
+        <div class="cardinal-grid">
+          <div class="cardinal-card">
+            <div class="mark-icon-cell">
+              <svg
+                width="44"
+                height="44"
+                viewBox="0 0 24 24"
+                aria-label="North cardinal mark — black over yellow"
+              >
+                <rect x="8" y="4" width="8" height="8" fill="#000" />
+                <rect x="8" y="12" width="8" height="8" fill="#ca8a04" />
+                <rect
+                  x="8"
+                  y="4"
+                  width="8"
+                  height="16"
+                  fill="none"
+                  stroke="#374151"
+                  stroke-width="1"
+                />
+              </svg>
+            </div>
+            <div>
+              <strong>North Cardinal</strong>
+              <div class="bands">BY &mdash; Black / Yellow</div>
+              <p>
+                Safe water is to the <strong>north</strong>. Black band on top points towards the
+                North Pole.
+              </p>
+            </div>
+          </div>
+
+          <div class="cardinal-card">
+            <div class="mark-icon-cell">
+              <svg
+                width="44"
+                height="44"
+                viewBox="0 0 24 24"
+                aria-label="South cardinal mark — yellow over black"
+              >
+                <rect x="8" y="4" width="8" height="8" fill="#ca8a04" />
+                <rect x="8" y="12" width="8" height="8" fill="#000" />
+                <rect
+                  x="8"
+                  y="4"
+                  width="8"
+                  height="16"
+                  fill="none"
+                  stroke="#374151"
+                  stroke-width="1"
+                />
+              </svg>
+            </div>
+            <div>
+              <strong>South Cardinal</strong>
+              <div class="bands">YB &mdash; Yellow / Black</div>
+              <p>
+                Safe water is to the <strong>south</strong>. Black band on bottom points towards the
+                South Pole.
+              </p>
+            </div>
+          </div>
+
+          <div class="cardinal-card">
+            <div class="mark-icon-cell">
+              <svg
+                width="44"
+                height="44"
+                viewBox="0 0 24 24"
+                aria-label="East cardinal mark — black yellow black"
+              >
+                <rect x="8" y="4" width="8" height="5.33" fill="#000" />
+                <rect x="8" y="9.33" width="8" height="5.34" fill="#ca8a04" />
+                <rect x="8" y="14.67" width="8" height="5.33" fill="#000" />
+                <rect
+                  x="8"
+                  y="4"
+                  width="8"
+                  height="16"
+                  fill="none"
+                  stroke="#374151"
+                  stroke-width="1"
+                />
+              </svg>
+            </div>
+            <div>
+              <strong>East Cardinal</strong>
+              <div class="bands">BYB &mdash; Black / Yellow / Black</div>
+              <p>
+                Safe water is to the <strong>east</strong>. Yellow band trapped in the centre
+                &mdash; like a sunrise breaking through.
+              </p>
+            </div>
+          </div>
+
+          <div class="cardinal-card">
+            <div class="mark-icon-cell">
+              <svg
+                width="44"
+                height="44"
+                viewBox="0 0 24 24"
+                aria-label="West cardinal mark — yellow black yellow"
+              >
+                <rect x="8" y="4" width="8" height="5.33" fill="#ca8a04" />
+                <rect x="8" y="9.33" width="8" height="5.34" fill="#000" />
+                <rect x="8" y="14.67" width="8" height="5.33" fill="#ca8a04" />
+                <rect
+                  x="8"
+                  y="4"
+                  width="8"
+                  height="16"
+                  fill="none"
+                  stroke="#374151"
+                  stroke-width="1"
+                />
+              </svg>
+            </div>
+            <div>
+              <strong>West Cardinal</strong>
+              <div class="bands">YBY &mdash; Yellow / Black / Yellow</div>
+              <p>
+                Safe water is to the <strong>west</strong>. Black band in the middle forms an
+                hourglass shape.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <h3>Safe water marks</h3>
+        <div class="mark-list">
+          <div class="mark-row">
+            <div class="mark-icon-cell">
+              <svg
+                width="48"
+                height="48"
+                viewBox="0 0 24 24"
+                aria-label="Safe water mark — red and white vertical stripes"
+              >
+                <rect x="8" y="4" width="2" height="16" fill="#dc2626" />
+                <rect x="10" y="4" width="2" height="16" fill="#fff" />
+                <rect x="12" y="4" width="2" height="16" fill="#dc2626" />
+                <rect x="14" y="4" width="2" height="16" fill="#fff" />
+                <rect
+                  x="8"
+                  y="4"
+                  width="8"
+                  height="16"
+                  fill="none"
+                  stroke="#374151"
+                  stroke-width="1"
+                />
+              </svg>
+            </div>
+            <div class="mark-info">
+              <strong><span class="symbol-code">RW</span> Safe Water Mark</strong>
+              <p>
+                Red and white vertical stripes. Indicates open, navigable water all around &mdash;
+                no hazard nearby. Can be passed on either side. Often marks the centre of a channel
+                or a fairway approach.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <h3>Special marks</h3>
+        <div class="mark-list">
+          <div class="mark-row">
+            <div class="mark-icon-cell">
+              <svg
+                width="48"
+                height="48"
+                viewBox="0 0 24 24"
+                aria-label="Special mark — yellow circle"
+              >
+                <circle cx="12" cy="12" r="10" fill="#ca8a04" stroke="#374151" stroke-width="1" />
+              </svg>
+            </div>
+            <div class="mark-info">
+              <strong><span class="symbol-code">Y</span> Special Mark</strong>
+              <p>
+                Yellow buoy. Used for special purposes not covered by the other categories &mdash;
+                most commonly racing marks.
+                <strong>The vast majority of Solent racing marks are special marks.</strong> They
+                are not navigation hazards; racers round them as instructed by the sailing
+                instructions.
+              </p>
+            </div>
+          </div>
+
+          <div class="mark-row">
+            <div class="mark-icon-cell">
+              <svg
+                width="48"
+                height="48"
+                viewBox="0 0 24 24"
+                aria-label="Blue mark — blue cylinder"
+              >
+                <rect
+                  x="8"
+                  y="4"
+                  width="8"
+                  height="16"
+                  fill="#2563eb"
+                  stroke="#374151"
+                  stroke-width="1"
+                />
+              </svg>
+            </div>
+            <div class="mark-info">
+              <strong><span class="symbol-code">B</span> Blue Mark</strong>
+              <p>
+                Blue cylindrical buoy. Appears for a small number of marks in the game dataset.
+                Treat as a lateral mark for navigation purposes.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Section 2: How the game works -->
+      <section>
+        <h2>2. How the game works</h2>
+
+        <p>
+          Each round you are shown a racing mark highlighted on an interactive map with nearby
+          context marks visible. Choose the correct name from the options given before the timer
+          runs out. The faster you answer, the higher your score.
+        </p>
+
+        <h3>Difficulty levels</h3>
+
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Difficulty</th>
+                <th>Time limit</th>
+                <th>Mark pool</th>
+                <th>Multiplier</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><strong>Beginner</strong></td>
+                <td>30 s</td>
+                <td>
+                  Famous landmarks without sponsors &mdash; towers, forts, lighthouses, banks, and
+                  ledges
+                </td>
+                <td>&times;1</td>
+              </tr>
+              <tr>
+                <td><strong>Intermediate</strong></td>
+                <td>20 s</td>
+                <td>Sponsored marks, buoys, elbows, and headlands</td>
+                <td>&times;1.5</td>
+              </tr>
+              <tr>
+                <td><strong>Advanced</strong></td>
+                <td>10 s</td>
+                <td>All 157 Solent marks</td>
+                <td>&times;2</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <h3>Scoring</h3>
+        <p>
+          Every correct answer earns a base of <strong>100 points</strong> plus a time bonus for
+          answering quickly. The total is then multiplied by the difficulty multiplier.
+        </p>
+
+        <div class="score-grid">
+          <div class="score-card">
+            <span class="num">100</span>
+            <span class="label">Base points (correct)</span>
+          </div>
+          <div class="score-card">
+            <span class="num">+30&ndash;70</span>
+            <span class="label">Max time bonus</span>
+          </div>
+          <div class="score-card">
+            <span class="num">&times;1&ndash;2</span>
+            <span class="label">Difficulty multiplier</span>
+          </div>
+          <div class="score-card">
+            <span class="num">+100</span>
+            <span class="label">Max streak bonus</span>
+          </div>
+        </div>
+
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Difficulty</th>
+                <th>Max time bonus</th>
+                <th>Multiplier</th>
+                <th>Max score per question</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Beginner</td>
+                <td>+30</td>
+                <td>&times;1</td>
+                <td>130</td>
+              </tr>
+              <tr>
+                <td>Intermediate</td>
+                <td>+50</td>
+                <td>&times;1.5</td>
+                <td>225</td>
+              </tr>
+              <tr>
+                <td>Advanced</td>
+                <td>+70</td>
+                <td>&times;2</td>
+                <td>340</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <div class="callout gold">
+          <p style="margin: 0; font-size: 0.85rem">
+            <strong>Streak bonus:</strong> Answer 3 or more marks correctly in a row to earn a
+            streak bonus. The bonus is 10&nbsp;&times;&nbsp;your current streak length, capped at
+            100 bonus points per answer. A streak of 3 earns +30; a streak of 10 or more earns the
+            maximum +100.
+          </p>
+        </div>
+
+        <h3>Special modes</h3>
+
+        <div class="mark-list">
+          <div class="mark-row">
+            <div class="mark-icon-cell" style="font-size: 1.5rem; color: #ca8a04">&#9733;</div>
+            <div class="mark-info">
+              <strong>Cowes Daring Mode</strong>
+              <p>
+                Restricts the mark pool to those within 5&nbsp;km of Cowes harbour centre &mdash;
+                the busiest racing waters in the Solent. A focused challenge for Cowes regulars or
+                anyone preparing for Cowes Week.
+              </p>
+            </div>
+          </div>
+
+          <div class="mark-row">
+            <div class="mark-icon-cell" style="font-size: 1.5rem; color: #718096">&#128161;</div>
+            <div class="mark-info">
+              <strong>Hints for sponsored marks</strong>
+              <p>
+                Enable this option to see the sponsor name as a clue for sponsored marks. Useful
+                when you&#8217;re starting out and the sponsor is a familiar local name.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Section 3: Tips for learning -->
+      <section>
+        <h2>3. Tips for learning the Solent marks</h2>
+
+        <ul class="tip-list">
+          <li>
+            <strong>Start with beginner mode — landmarks first</strong>
+            Forts, towers, lighthouses, and named banks are fixed geographical references that do
+            not change with sponsors. Learning Horse Sand Fort, No Man&#8217;s Land Fort, and the
+            shipping channel banks gives you a reliable mental map before tackling sponsored marks.
+          </li>
+          <li>
+            <strong>Learn by area, not by number</strong>
+            Group marks mentally by the waters you know: Southampton Water, the Lymington River, the
+            Hamble, Chichester Harbour approaches. Once you have a cluster of marks in one area
+            nailed, move to the next. The game&#8217;s map always shows nearby context marks so you
+            can orient yourself geographically.
+          </li>
+          <li>
+            <strong>Enable the nautical chart layer</strong>
+            Switching on the OpenSeaMap overlay shows depth contours, shoal areas, and channel
+            markers. Cross-referencing the racing mark against a depth feature or a shipping lane
+            often gives a powerful positional clue.
+          </li>
+          <li>
+            <strong>Check the 2026 changes before racing</strong>
+            23 marks were renamed between 2025 and 2026, mostly due to sponsor changes. If you raced
+            last season, some familiar names will have changed. See the
+            <a href="/solent-racing-marks-2026/">2026 mark changes page</a> for the full list.
+          </li>
+        </ul>
+      </section>
+
+      <!-- CTA -->
+      <div class="cta">
+        <h2>Ready to test yourself?</h2>
+        <p>
+          Put your knowledge to the test on all 157 Solent marks &mdash; from Beginner to Advanced.
+          How many can you name?
+        </p>
+        <a href="/" class="btn">Play Guess the Mark &rarr;</a>
+      </div>
+    </main>
+
+    <footer>
+      <p>
+        Mark data:
+        <a href="https://www.scra.org.uk/" target="_blank" rel="noopener noreferrer">SCRA</a> via
+        <a
+          href="https://winningtides.co.uk/pages/buoyracer.htm"
+          target="_blank"
+          rel="noopener noreferrer"
+          >Winning Tides</a
+        >. &copy; 2026 Guess the Mark &middot; <a href="/">Play the game</a> &middot;
+        <a href="/solent-racing-marks-2026/">2026 mark changes</a>
+      </p>
+    </footer>
+  </body>
+</html>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -12,4 +12,10 @@
     <changefreq>yearly</changefreq>
     <priority>0.8</priority>
   </url>
+  <url>
+    <loc>https://guess-the-mark.verdient.co.uk/learn/</loc>
+    <lastmod>2026-06-11</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.8</priority>
+  </url>
 </urlset>

--- a/public/solent-racing-marks-2026/index.html
+++ b/public/solent-racing-marks-2026/index.html
@@ -710,7 +710,8 @@
           target="_blank"
           rel="noopener noreferrer"
           >Winning Tides</a
-        >. &copy; 2026 Guess the Mark.
+        >. &copy; 2026 Guess the Mark &middot;
+        <a href="/learn/">Learn the marks</a>
       </p>
     </footer>
   </body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -292,6 +292,10 @@ function App() {
                   >
                     2026 mark changes
                   </a>
+                  {" · "}
+                  <a href="/learn/" className="text-slate-500 hover:text-[#1B2A4A] underline">
+                    Learn the marks
+                  </a>
                 </p>
               </div>
             </div>


### PR DESCRIPTION
## Summary

- Adds a static, self-contained `/learn/index.html` tutorial page at `https://guess-the-mark.verdient.co.uk/learn/`
- Inline SVGs match the in-game `MarkIcon` shapes exactly (port/starboard/safe water/cardinal/special marks)
- Three sections: IALA buoyage explainer, how the game works (scoring/difficulty from `gameLogic.ts`), tips for learning the Solent marks
- SEO head: title, canonical, OG tags, JSON-LD `Article` + `FAQPage` with 4 Q&As
- Added to `sitemap.xml`; bidirectional links from `App.tsx` footer and the 2026 changes page footer

## Test plan

- [ ] `pnpm run ci` passes (format check, lint, 60 tests, build) — verified locally
- [ ] `dist/client/learn/index.html` present in build output — verified
- [ ] `/learn/` page renders correctly in browser (no JS, mobile-friendly)
- [ ] `/` game start screen shows "Learn the marks" footer link
- [ ] `/solent-racing-marks-2026/` footer shows "Learn the marks" cross-link
- [ ] All cross-links resolve correctly in preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)